### PR TITLE
[JENKINS-40422] Inferring credentials resolves wrong credential

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
@@ -409,7 +409,7 @@ public final class GitHubStatusNotificationStep extends AbstractStepImpl {
         }
 
         private String tryToInferCredentialsId() {
-            String credentialsID = getSource().getCredentialsId();
+            String credentialsID = getSource().getScanCredentialsId();
             if (credentialsID != null) {
                 return credentialsID;
             } else {


### PR DESCRIPTION
[JENKINS-40422](https://issues.jenkins-ci.org/browse/JENKINS-40422) Use scanCredentials if available over checkoutCredentials when inferring

When you use a separate set of credentials for checkout and scanning
it makes sense to use the scan credentials to notify, for example it could
be that checkout credentials are of type SSH whilst scan are of type username/
password, or even that due to GH API limits both of them may be adecuate
but you want to use the scan ones

@reviewbybees