### PR TITLE
[JENKINS-43370] Fix proxy resolution for enterprise Githubs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
@@ -66,6 +66,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.net.Proxy;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
@@ -249,10 +250,12 @@ public final class GitHubStatusNotificationStep extends AbstractStepImpl {
         githubBuilder.withOAuthToken(credentials.getPassword().getPlainText(), credentials.getUsername());
 
         if (gitApiUrl == null || gitApiUrl.isEmpty()) {
-            githubBuilder = githubBuilder.withProxy(getProxy("https://api.github.com"));
+            githubBuilder = githubBuilder.withProxy(getProxy("api.github.com"));
         } else {
             githubBuilder = githubBuilder.withEndpoint(gitApiUrl);
-            githubBuilder = githubBuilder.withProxy(getProxy(gitApiUrl));
+
+            URL url = new URL(gitApiUrl);
+            githubBuilder = githubBuilder.withProxy(getProxy(url.getHost()));
         }
 
         GitHub github = githubBuilder.build();


### PR DESCRIPTION
The [Jenkins ProxyConfiguration class](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/ProxyConfiguration.java) expects only the hostname (e.g. `git.example.com` vs `https://git.example.com/api/`) as a method parameter to `createProxy`, but the existing code gives it the whole URL.
As a result of this, the validation of no-proxy hosts list is not correct. This is not noticeable when using github.com (altough the https:// should not be there either), but it fails when using enterprise githubs.