### PR TITLE
Update github-api to 1.90

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.77</version>
+            <version>1.90</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This release contains the fix for 64 bit integers: kohsuke/github-api@7735edeae87652c1fa8196e7956851a39f5a84d4