### PR TITLE
Do not fail step in case commit is not found (422)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+work

--- a/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
@@ -373,14 +373,11 @@ public final class GitHubStatusNotificationStep extends AbstractStepImpl {
         @Inject
         private transient GitHubStatusNotificationStep step;
 
-        @Inject
-        private transient TaskListener listener;
-
         @StepContextParameter
         private transient Run run;
 
         @Override
-        protected Void run() {
+        protected Void run() throws Exception {
             String targetUrl = getTargetUrl();
             String credentialsId = getCredentialsId();
             String repo = getRepo();
@@ -389,7 +386,7 @@ public final class GitHubStatusNotificationStep extends AbstractStepImpl {
             try {
                 repository = getRepoIfValid(credentialsId, step.getGitApiUrl(), account, repo, run.getParent());
             } catch (IOException x) {
-                listener.error("Could not check repository settings").print(Functions.printThrowable(x)); // TODO Jenkins ~2.42+: Functions.printStackTrace
+                getContext().get(TaskListener.class).error("Could not check repository settings").print(Functions.printThrowable(x)); // TODO Jenkins ~2.42+: Functions.printStackTrace
                 return null;
             }
             String sha1 = getSha1();
@@ -397,14 +394,14 @@ public final class GitHubStatusNotificationStep extends AbstractStepImpl {
             try {
                 commit = repository.getCommit(sha1);
             } catch (IOException ex) {
-                listener.error(INVALID_COMMIT).print(Functions.printThrowable(ex)); // TODO Jenkins ~2.42+: Functions.printStackTrace
+                getContext().get(TaskListener.class).error(INVALID_COMMIT).print(Functions.printThrowable(ex)); // TODO Jenkins ~2.42+: Functions.printStackTrace
                 return null;
             }
             try {
                 repository.createCommitStatus(commit.getSHA1(),
                     step.getStatus(), targetUrl, step.getDescription(), step.getContext());
             } catch (IOException x) {
-                listener.error("Could not update commit status").print(Functions.printThrowable(x)); // TODO Jenkins ~2.42+: Functions.printStackTrace
+                getContext().get(TaskListener.class).error("Could not update commit status").print(Functions.printThrowable(x)); // TODO Jenkins ~2.42+: Functions.printStackTrace
                 return null;
             }
             return null;

--- a/src/test/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubNotificationPipelineStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubNotificationPipelineStepTest.java
@@ -194,6 +194,7 @@ public class GitHubNotificationPipelineStepTest {
         ));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
         jenkins.assertBuildStatus(Result.FAILURE, jenkins.waitForCompletion(b1));
+        Thread.sleep(1000); // TODO pending workflow-job bump
         jenkins.assertLogContains(GitHubStatusNotificationStep.Execution.UNABLE_TO_INFER_COMMIT, b1);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubNotificationPipelineStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubNotificationPipelineStepTest.java
@@ -136,7 +136,7 @@ public class GitHubNotificationPipelineStepTest {
     }
 
     @Test
-    public void buildWithWrongCommitMustFail() throws Exception {
+    public void buildWithWrongCommitMustWarn() throws Exception {
 
         GitHubBuilder ghb = PowerMockito.mock(GitHubBuilder.class);
         PowerMockito.when(ghb.withProxy(Matchers.<Proxy>anyObject())).thenReturn(ghb);
@@ -162,7 +162,7 @@ public class GitHubNotificationPipelineStepTest {
                         "status: 'SUCCESS', targetUrl: 'http://www.cloudbees.com'"
         ));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
-        jenkins.assertBuildStatus(Result.FAILURE, jenkins.waitForCompletion(b1));
+        jenkins.assertBuildStatus(Result.SUCCESS, jenkins.waitForCompletion(b1));
         jenkins.assertLogContains(GitHubStatusNotificationStep.INVALID_COMMIT, b1);
     }
 


### PR DESCRIPTION
Saw a build fail because it was using this step on a merge commit from a PR, which does not exist remotely. That seems like overkill—notification to GitHub should be a best effort.

```
[Pipeline] End of Pipeline
java.io.IOException: Server returned HTTP response code: 422 for URL: https://api.github.com/repos/…/…/commits/…
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1894)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
	at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:347)
	at org.kohsuke.github.Requester.parse(Requester.java:615)
Caused: java.io.IOException: Server returned HTTP response code: 422 for URL: https://api.github.com/repos/…/…/commits/…
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1944)
	at sun.net.www.protocol.http.HttpURLConnection$10.run(HttpURLConnection.java:1939)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.net.www.protocol.http.HttpURLConnection.getChainedException(HttpURLConnection.java:1938)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1508)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:263)
	at org.kohsuke.github.Requester.parse(Requester.java:625)
Caused: org.kohsuke.github.HttpException: Server returned HTTP response code: 422, message: 'Unprocessable Entity' for URL: https://api.github.com/repos/…/…/commits/…
	at org.kohsuke.github.Requester.parse(Requester.java:646)
	at org.kohsuke.github.Requester.parse(Requester.java:607)
	at org.kohsuke.github.Requester._to(Requester.java:285)
Caused: org.kohsuke.github.HttpException: {"message":"No commit found for SHA: …","documentation_url":"https://developer.github.com/v3/repos/commits/#get-a-single-commit"}
	at org.kohsuke.github.Requester.handleApiError(Requester.java:703)
	at org.kohsuke.github.Requester._to(Requester.java:306)
	at org.kohsuke.github.Requester.to(Requester.java:247)
	at org.kohsuke.github.GHRepository.getCommit(GHRepository.java:973)
	at org.jenkinsci.plugins.pipeline.githubstatusnotification.GitHubStatusNotificationStep$Execution.run(GitHubStatusNotificationStep.java:377)
Caused: java.lang.IllegalArgumentException: The specified commit does not exist in the specified repository
	at org.jenkinsci.plugins.pipeline.githubstatusnotification.GitHubStatusNotificationStep$Execution.run(GitHubStatusNotificationStep.java:379)
	at org.jenkinsci.plugins.pipeline.githubstatusnotification.GitHubStatusNotificationStep$Execution.run(GitHubStatusNotificationStep.java:355)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
	at hudson.security.ACL.impersonate(ACL.java:290)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Finished: FAILURE
```

The [API docs](https://developer.github.com/v3/repos/commits/#get-a-single-commit) as usual do not document return codes; GitHub staff has told me in the past that they should be obvious. They are not, but 422 is at least documented for [“invalid fields”](https://developer.github.com/v3/#client-errors).