### PR TITLE
ensure legal description

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/githubstatusnotification/GitHubStatusNotificationStep.java
@@ -147,7 +147,7 @@ public final class GitHubStatusNotificationStep extends AbstractStepImpl {
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        this.description = String.format("%-140.140s", description).trim();
     }
 
     @DataBoundSetter


### PR DESCRIPTION
Sending a description with `\n` or too long will fail. This just makes sure the description is legal.